### PR TITLE
Improve zmq_term signal masking.

### DIFF
--- a/cbits/cbits.c
+++ b/cbits/cbits.c
@@ -4,11 +4,40 @@
 
 #include <signal.h>
 
+typedef void (*sighandler_t)(int);
+
 int term (void* ctx) {
-        int i;
-        for (i = 1; i < NSIG; ++i)
-                signal (i, SIG_IGN);
-        return zmq_term (ctx);
+        int i, ret;
+        /* signals NOT to mask during termination */
+        const int signal_retain[] = { SIGQUIT, SIGILL, SIGFPE, SIGSEGV, SIGTERM };
+        const int num_retained = sizeof signal_retain / sizeof signal_retain[0];
+        /* signals to mask during termination */
+        int signal_mask[NSIG];
+        int num_masked = 0;
+        /* signal handlers to restore after termination */
+        sighandler_t saved_handlers[NSIG];
+
+        /* build an array of signals to mask */
+        for (i = 1; i < NSIG; ++i) {
+                int j;
+                for (j = 0; j < num_retained; ++j)
+                        if (i == signal_retain[j]) break;
+                if (j == num_retained)
+                        signal_mask[num_masked++] = i;
+        }
+
+        /* disable all but the specified signals */
+        for (i = 0; i < num_masked; ++i)
+                saved_handlers[i] = signal (signal_mask[i], SIG_IGN);
+
+        ret = zmq_term (ctx);
+
+        /* restore all previously disabled signal handlers */
+        for (i = 0; i < num_masked; ++i)
+                if (saved_handlers[i] != SIG_ERR)
+                        signal (signal_mask[i], saved_handlers[i]);
+
+        return ret;
 }
 
 #else


### PR DESCRIPTION
When masking signals around the call to zmq_term, it is desirable for
some signals not to be blocked, e.g., termination signals such as
SIGTERM.  Given that zmq_term may linger on open sockets for some time, in some scenarios it may be necessary for an external process to abort that linger process without necessarily being so violent as sending a SIGKILL.  For these reasons, in this commit I loosened the signal mask to exclude the following extreme-condition signals:
- SIGQUIT
- SIGILL
- SIGFPE
- SIGSEGV
- SIGTERM

Also, if signal handlers are set to SIG_IGN to mask the signals during
the execution of zmq_term, it is desirable that they be restored at its
completion.  While in many applications the call to terminate the ZeroMQ
context will occur at application's end, there will be some which do
other computations after the context is released.  Therefore, this
commit restores the signal handlers after zmq_term returns.
