### PR TITLE
Make zmq_device interruptible.

### DIFF
--- a/src/System/ZMQ/Base.hsc
+++ b/src/System/ZMQ/Base.hsc
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, ForeignFunctionInterface #-}
+{-# LANGUAGE CPP, ForeignFunctionInterface, InterruptibleFFI #-}
 -- |
 -- Module      : System.ZMQ.Base
 -- Copyright   : (c) 2010-2011 Toralf Wittner
@@ -126,7 +126,7 @@ newtype ZMQDevice = ZMQDevice { deviceType :: CInt } deriving (Eq, Ord)
     deviceQueue     = ZMQ_QUEUE
 }
 
-foreign import ccall safe "zmq.h zmq_device"
+foreign import ccall interruptible "zmq.h zmq_device"
     c_zmq_device :: CInt -> ZMQSocket -> ZMQSocket -> IO CInt
 
 -- general initialization


### PR DESCRIPTION
It is sometimes desirable to run a zmq_device call in a thread other
than the main thread (e.g., when more than one zmq_device call must be made).  To cleanly unwind the program, the main thread
must tell the device thread to exit, thereby closing its sockets.
Unfortunately, it is not possible to interrupt a "safe" FFI call with an
asynchronous exception.  Therefore, we have change the foreign
declaration for zmq_device from "safe" to "interruptible" to enable this type of teardown.
