### PR TITLE
Expose c_zmq_curve_keypair via curveKeyPair

### DIFF
--- a/src/System/ZMQ4.hs
+++ b/src/System/ZMQ4.hs
@@ -198,6 +198,7 @@ module System.ZMQ4
 
     -- * Utils
   , proxy
+  , curveKeyPair
   ) where
 
 import Prelude hiding (init)
@@ -955,3 +956,12 @@ proxy front back capture =
         throwIfMinus1Retry_ "c_zmq_proxy" $ c_zmq_proxy f b c
   where
     c = maybe nullPtr (_socket . _socketRepr) capture
+
+curveKeyPair :: IO (Restricted Div5 SB.ByteString, Restricted Div5 SB.ByteString)
+curveKeyPair =
+    allocaBytes 41 $ \cstr1 ->
+    allocaBytes 41 $ \cstr2 -> do
+        throwIfMinus1_ "c_zmq_curve_keypair" $ c_zmq_curve_keypair cstr1 cstr2
+        public  <- restrict <$> SB.packCString cstr1
+        private <- restrict <$> SB.packCString cstr2
+        return (public, private)

--- a/src/System/ZMQ4/Base.hsc
+++ b/src/System/ZMQ4/Base.hsc
@@ -353,3 +353,8 @@ foreign import ccall unsafe "zmq.h zmq_z85_encode"
 foreign import ccall unsafe "zmq.h zmq_z85_decode"
     c_zmq_z85_decode :: Ptr Word8 -> CString -> IO (Ptr Word8)
 
+-- curve crypto
+
+foreign import ccall unsafe "zmq.h zmq_curve_keypair"
+    c_zmq_curve_keypair :: CString -> CString -> IO CInt
+

--- a/src/System/ZMQ4/Monadic.hs
+++ b/src/System/ZMQ4/Monadic.hs
@@ -175,6 +175,7 @@ module System.ZMQ4.Monadic
   , waitWrite
   , I.z85Encode
   , I.z85Decode
+  , Z.curveKeyPair
   ) where
 
 import Control.Applicative


### PR DESCRIPTION
Can I please have something like this?

I'd like to generate client keys on the fly, by calling this:
http://api.zeromq.org/4-0:zmq-curve-keypair

Crypto support currently works perfectly for me, by the way.

This pull request works, I didn't know where to put things though and I've only been using haskell for a month or two now. So. Careful.
