### PR TITLE
Make modules visible.

### DIFF
--- a/zeromq4-haskell.cabal
+++ b/zeromq4-haskell.cabal
@@ -42,12 +42,10 @@ library
     exposed-modules:
         System.ZMQ4
         System.ZMQ4.Monadic
-        Data.Restricted
-
-    other-modules:
         System.ZMQ4.Base
         System.ZMQ4.Internal
         System.ZMQ4.Error
+        Data.Restricted
 
     ghc-options:       -Wall -O2 -fwarn-tabs -funbox-strict-fields
 


### PR DESCRIPTION
This patch allow user to not reintroduce internals in case if they
are needed.
