### PR TITLE
Fix compatibility with previous GHC versions

### DIFF
--- a/zeromq4-haskell.cabal
+++ b/zeromq4-haskell.cabal
@@ -61,6 +61,9 @@ library
         , semigroups   >= 0.8
         , transformers >= 0.3
 
+    if impl(ghc < 7.6)
+        build-depends: ghc-prim
+
     if os(windows)
         extra-libraries: zmq
     else


### PR DESCRIPTION
Modify cabal file to include ghc-prim in build-depends when
GHC version is smaller than 7.6.

Signed-off-by: Spyros Trigazis strigazi@gmail.com
