### PR TITLE
Move towards higher-level API (add 'Message' type)

### DIFF
--- a/src/System/ZMQ4/Internal/Base.hsc
+++ b/src/System/ZMQ4/Internal/Base.hsc
@@ -6,6 +6,7 @@
 -- to change without notice.
 module System.ZMQ4.Internal.Base where
 
+import Data.Bits
 import Foreign
 import Foreign.C.Types
 import Foreign.C.String
@@ -239,6 +240,20 @@ newtype ZMQMsgOption = ZMQMsgOption
 newtype ZMQFlag = ZMQFlag
   { flagVal :: CInt
   } deriving (Eq, Ord)
+
+instance Bits ZMQFlag where
+    ZMQFlag x .&. ZMQFlag y   = ZMQFlag (x .&. y)
+    ZMQFlag x .|. ZMQFlag y   = ZMQFlag (x .|. y)
+    ZMQFlag x `xor` ZMQFlag y = ZMQFlag (x `xor` y)
+    complement (ZMQFlag x)    = ZMQFlag (complement x)
+    ZMQFlag x `shift` n       = ZMQFlag (x `shift` n)
+    ZMQFlag x `rotate` n      = ZMQFlag (x `rotate` n)
+    bitSize (ZMQFlag x)       = bitSize x
+    bitSizeMaybe (ZMQFlag x)  = bitSizeMaybe x
+    isSigned (ZMQFlag x)      = isSigned x
+    ZMQFlag x `testBit` n     = x `testBit` n
+    bit                       = ZMQFlag . bit
+    popCount (ZMQFlag x)      = popCount x
 
 #{enum ZMQFlag, ZMQFlag
   , dontWait = ZMQ_DONTWAIT

--- a/src/System/ZMQ4/Monadic.hs
+++ b/src/System/ZMQ4/Monadic.hs
@@ -17,6 +17,8 @@ module System.ZMQ4.Monadic
   ( -- * Type Definitions
     ZMQ
   , Socket
+  , Z.Frame
+  , Z.Message           (..)
   , Z.Flag              (..)
   , Z.Switch            (..)
   , Z.Timeout
@@ -71,10 +73,7 @@ module System.ZMQ4.Monadic
   , connect
   , disconnect
   , send
-  , send'
-  , sendMulti
   , receive
-  , receiveMulti
   , subscribe
   , unsubscribe
   , proxy
@@ -188,7 +187,6 @@ import Control.Monad.IO.Class
 import Control.Monad.Catch
 import Data.Int
 import Data.IORef
-import Data.List.NonEmpty (NonEmpty)
 import Data.Restricted
 import Data.Word
 import Data.ByteString (ByteString)
@@ -198,7 +196,6 @@ import Prelude
 import qualified Control.Concurrent.Async as A
 import qualified Control.Exception        as E
 import qualified Control.Monad.Catch      as C
-import qualified Data.ByteString.Lazy     as Lazy
 import qualified System.ZMQ4              as Z
 import qualified System.ZMQ4.Internal     as I
 
@@ -325,20 +322,11 @@ connect s = liftIO . Z.connect (_unsocket s)
 disconnect :: Socket z t -> String -> ZMQ z ()
 disconnect s = liftIO . Z.disconnect (_unsocket s)
 
-send :: Z.Sender t => Socket z t -> [Z.Flag] -> ByteString -> ZMQ z ()
-send s f = liftIO . Z.send (_unsocket s) f
+send :: Z.Sender t => Socket z t -> I.Message -> ZMQ z ()
+send s = liftIO . Z.send (_unsocket s)
 
-send' :: Z.Sender t => Socket z t -> [Z.Flag] -> Lazy.ByteString -> ZMQ z ()
-send' s f = liftIO . Z.send' (_unsocket s) f
-
-sendMulti :: Z.Sender t => Socket z t -> NonEmpty ByteString -> ZMQ z ()
-sendMulti s = liftIO . Z.sendMulti (_unsocket s)
-
-receive :: Z.Receiver t => Socket z t -> ZMQ z ByteString
+receive :: Z.Receiver t => Socket z t -> ZMQ z I.Message
 receive = liftIO . Z.receive . _unsocket
-
-receiveMulti :: Z.Receiver t => Socket z t -> ZMQ z [ByteString]
-receiveMulti = liftIO . Z.receiveMulti . _unsocket
 
 subscribe :: Z.Subscriber t => Socket z t -> ByteString -> ZMQ z ()
 subscribe s = liftIO . Z.subscribe (_unsocket s)


### PR DESCRIPTION
I think there is a lot of room for this library to be much higher level (closer to czmq as opposed to libzmq). One easy win is to (like czmq) introduce a "Message" newtype (just a linked list of frames, i.e. strict bytestrings) similar to a `zmsg_t`.

In creating such a Message type I had to choose once and for all which flavor of ByteString is appropriate. I think strict is a much more natural fit, especially a zmq message has to fit entirely in memory anyway, no matter how many parts it has.

So, in summary:

- Added `Message` newtype around `[ByteString]`
- Change type of `send` and `receive` to use `Message` rather than `[ByteString]` / `NonEmpty ByteString` (thus, they are like `sendMulti` and `receiveMulti` from before). The NonEmpty didn't really make sense to me, as there is such a thing as a zero-part zmq message. The types as written made it awkward to write a simple proxy such as `receiveMulti >>= sendMulti`
- Remove flags argument to `send`; the SENDMORE flag is set implicitly, as `sendMulti` did.
- Remove lazy `send'` and `receive'` as we don't deal explicitly with ByteStrings anymore. I don't see this as a huge loss.

Between the `IsList` instance for `Message` and the exported projection function, I don't think it will be too much more awkward to deal with messages now.

Are these welcome changes? Thanks for any feedback.
