### PR TITLE
Add MonadBase and MonadBaseControl instances

### DIFF
--- a/zeromq4-haskell.cabal
+++ b/zeromq4-haskell.cabal
@@ -58,6 +58,8 @@ library
         , exceptions   >= 0.6 && < 1.0
         , semigroups   >= 0.8
         , transformers >= 0.3
+        , monad-control
+        , transformers-base
 
     if impl(ghc < 7.6)
         build-depends: ghc-prim == 0.3.*


### PR DESCRIPTION
This PR adds `MonadBase IO` and `MonadBaseControl IO` instances. They are needed for working with some monad transformers (`AWST (ZMQ r) a` from `amazonka` for instance).
